### PR TITLE
fix new_kappa allocation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,9 @@ Authors@R: c(person("Thibaut", "Jombart",
 		    role = c("aut")),
 	     person("Gerry", "Tonkin-Hill",
 	            email = "gqt20@cam.ac.uk",
+		    role = c("ctb")),
+	     person("Alexis", "Robert",
+	            email = "alexis.robert@lshtm.ac.uk",
 		    role = c("ctb")))
 Maintainer: Finlay Campbell <f.campbell15@imperial.ac.uk>
 Description: Bayesian reconstruction of disease outbreaks using epidemiological

--- a/R/outbreaker_find_imports.R
+++ b/R/outbreaker_find_imports.R
@@ -27,7 +27,7 @@ outbreaker_find_imports <- function(moves, data, param_current,
     J <- length(moves)
 
     ## create matrix of individual influences ##
-    n_measures <- floor(config$n_iter_import - (1000 / config$sample_every_import))
+    n_measures <- floor((config$n_iter_import - 1000) / config$sample_every_import)
     influences <- matrix(0, ncol = data$N, nrow = n_measures)
     counter <- 1L
 

--- a/src/moves.cpp
+++ b/src/moves.cpp
@@ -582,7 +582,7 @@ Rcpp::List cpp_move_kappa(Rcpp::List param, Rcpp::List data, Rcpp::List config,
 	if (p_accept >= unif_rand()) { // accept new parameters
 	  // Rprintf("\naccepting kappa:%d  (p: %f  old ll:  %f  new ll: %f",
 	  // 		new_kappa[i], p_accept, old_loglike, new_loglike);
-	  param["kappa"] = new_kappa;
+	  kappa[i] = new_kappa[i];
 	} else {
 	  new_kappa[i] = kappa[i];
 	}


### PR DESCRIPTION
With the previous script, the allocation of new_kappa using param["kappa"] was interfering with the pointer definition. It was then causing errors in the computation of the new and old likelihoods (new_likelihood then corresponded to the old_likelihood).
In outbreaker_find_imports: there was a mistake in the position of the parentheses for the calculation of n_measures.