### PR TITLE
add RNGversion to tests

### DIFF
--- a/tests/testthat/test_non_exported.R
+++ b/tests/testthat/test_non_exported.R
@@ -1,5 +1,5 @@
 context("Test non-exported functions")
-
+current_R_version <- gsub("R version ([0-9.]+) .+$", "\\1", R.version.string) 
 
 ## test .choose_possible_alpha ##
 test_that("test: .choose_possible_alpha", {
@@ -52,11 +52,13 @@ test_that("Auxiliary functions for ancestries are working", {
   expect_equal(can_move_alpha(param, config2), c(TRUE, FALSE, TRUE, TRUE, FALSE, TRUE))
 
   ## test ancestor selection
+  RNGversion("3.5.2")
   set.seed(1)
   to_move <- replicate(10, select_alpha_to_move(param,config))
   expect_equal(to_move, c(3,3,4,6,3,6,6,5,5,1))
   to_move2 <- replicate(10, select_alpha_to_move(param,config2))
   expect_equal(to_move2, c(1,1,4,3,6,3,4,6,3,6))
+  RNGversion(current_R_version)
 
 })
 

--- a/tests/testthat/test_outbreaker.R
+++ b/tests/testthat/test_outbreaker.R
@@ -1,4 +1,5 @@
 context("Test outbreaker")
+current_R_version <- gsub("R version ([0-9.]+) .+$", "\\1", R.version.string) 
 
 ## test output format ##
 test_that("outbreaker's output have expected format", {
@@ -128,6 +129,8 @@ test_that("results ok: time, ctd, DNA", {
 
     ## outbreaker time, ctd, no DNA ##
     ## analysis
+    ## set the random number generator kind to old R
+    RNGversion("3.5.2")
     set.seed(1)
 
     tTree <- data.frame(i = x$ances,
@@ -161,6 +164,9 @@ test_that("results ok: time, ctd, DNA", {
         
     ## approx log post values
     expect_true(min(out_ctd.smry$post) > -1200)
+
+    ## reset the Random number generator kind
+    RNGversion(current_R_version)
 
 })
 


### PR DESCRIPTION
This will fix #55 by using RNGversion before the tests that have random number generation steps.