### PR TITLE
Shuffle indices in cpp_move_swap_cases()

### DIFF
--- a/src/moves.cpp
+++ b/src/moves.cpp
@@ -1,5 +1,6 @@
 #include <Rcpp.h>
 #include <Rmath.h>
+#include <algorithm>		// std::random_shuffle
 #include "internals.h"
 #include "likelihoods.h"
 #include "priors.h"
@@ -462,8 +463,12 @@ Rcpp::List cpp_move_swap_cases(Rcpp::List param, Rcpp::List data,
 
   double old_loglike = 0.0, new_loglike = 0.0, p_accept = 0.0;
 
+  // Shuffle indices to make equal cases equally likely
+  Rcpp::IntegerVector idx = Rcpp::seq(0, N-1);
+  std::random_shuffle (idx.begin(), idx.end());
 
-  for (size_t i = 0; i < N; i++) {
+  for (size_t j = 0; j < N; ++j) {
+    size_t i = (size_t)idx[j];
 
     // only non-NA ancestries are moved, if there is at least 1 choice
     if (alpha[i] != NA_INTEGER && sum(t_inf < t_inf[i]) > 0) {


### PR DESCRIPTION
If the iteration in cpp_move_swap_cases is in-order, then cases that are equal w.r.t. dna, dates and ctd are not equally likely to be picked as each others' ancestors. See reproducible example here: https://gist.github.com/kreldjarn/b0c6741f73c5790c92c1caa3ee3035b5

Consider the case where 1 -> 3 -> 2.
Then, when i==2, we swap 2 and 3 with 100% probability (since the likelihoods are equal) and we have 1 -> 2 -> 3.
In the next step i==3 and we swap 3 and 2 again with 100% probability and we end up as we started, with 1 -> 3 -> 2.

Now consider the case where 1 -> 2 -> 3.
When i==2 we most likely do nothing, because 1 -> 2 is more likely than 2 -> 1
In the next step i==3 we swap 3 and 2 with 100% probability, and end up with 1 -> 3 -> 2.

In both cases, we end up with the same order of infections, even though they are equally likely. Shuffling the indices before iterating fixes this problem.