### PR TITLE
Allow indices to be passed into custom likelihood functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ vignettes/*cache*
 docs/articles/*cache*
 doc
 Meta
+.*.swp
+.*.swo

--- a/R/custom_likelihoods.R
+++ b/R/custom_likelihoods.R
@@ -42,7 +42,8 @@
 #' A named list of list(function, arity) pairs with the class
 #'     \code{custom_likelihood}, each function implementing a customised
 #'     log-likelihood component of outbreaker. Functions which are not
-#'     customised will result in a list(NULL, 0) component.
+#'     customised will result in a list(NULL, 0) component. Any function with
+#'     arity 3 must have the third parameter default to NULL
 #'
 #' @author Thibaut Jombart (\email{thibautjombart@@gmail.com})
 #'

--- a/R/custom_likelihoods.R
+++ b/R/custom_likelihoods.R
@@ -39,10 +39,10 @@
 #'
 #'
 #' @return
-#' A named list of functions with the class \code{custom_likelihood}, each
-#'     implementing a customised log-likelihood components of
-#'     outbreaker. Functions which are not customised will result in a NULL
-#'     component.
+#' A named list of list(function, arity) pairs with the class
+#'     \code{custom_likelihood}, each function implementing a customised
+#'     log-likelihood component of outbreaker. Functions which are not
+#'     customised will result in a list(NULL, 0) component.
 #'
 #' @author Thibaut Jombart (\email{thibautjombart@@gmail.com})
 #'
@@ -88,12 +88,16 @@
 ## Likelihood functions in outbreaker2 are implemented using Rcpp. However,
 ## these functions can also be replaced by customized functions. These can be
 ## specified by the user, through the '...' argument of
-## 'custom_likelihoods'. These functions must have 2 arguments:
+## 'custom_likelihoods'. These functions must have at least 2 arguments:
 
 ## - data: a valid 'outbreaker_data' list
 
 ## - param: a list containing current parameter states, as returned by
 ## - create_param
+
+## - [i=NULL]: (optional) a list of the cases for which the loglikelihoods
+## - should be calculated. Needs to default to `NULL` in which case the
+## - loglikelihood of the entire tree is calculated.
 
 custom_likelihoods <- function(...) {
 
@@ -121,40 +125,49 @@ custom_likelihoods <- function(...) {
     function_or_null <- function(x) {
         is.null(x) || is.function(x)
     }
+    list_function_or_null <- function(x) {
+        is.list(x) && (is.null(x[[1]]) || is.function(x[[1]]))
+    }
 
-    is_ok <- vapply(likelihoods, function_or_null, logical(1))
+    # Ensure that custom_likelihoods(l) == custom_likelihoods(custom_likelihoods(l))
+    is_list_function_or_null <- vapply(likelihoods, list_function_or_null, logical(1))
+    is_function_or_null <- vapply(likelihoods, function_or_null, logical(1))
 
-    if (!all(is_ok)) {
-        culprits <- likelihoods_names[!is_ok]
+    if (!all(is_function_or_null) & !all(is_list_function_or_null)) {
+        culprits <- likelihoods_names[!is_function_or_null]
         msg <- paste0("The following likelihoods are not functions: ",
                       paste(culprits, collapse = ", "))
         stop(msg)
     }
 
-
-    ## check they all have a single argument
-
-    with_two_args <- function(x) {
-        if(is.function(x)) {
-            return (length(methods::formalArgs(x)) == 2L)
-        }
-
-        return(TRUE)
+    # If the arity of the likelihood functions is three, the last argumen should
+    # be the (1-based) indices of the cases we're currently perturbing. This
+    # allows us to calculate the local likelihood delta, rather than having to
+    # calculate the likelihood of the entire tree twice for every single
+    # perturbation we make.
+    if (!all(is_list_function_or_null)) {
+        likelihoods <- lapply(likelihoods, function(x) { if (is.null(x)) return(list(x, 0)); list(x, length(methods::formalArgs(x))) })
     }
 
-    two_args <- vapply(likelihoods, with_two_args, logical(1))
+    arity_two_or_three <- function(x) {
+        if (is.function(x[[1]])) {
+            return (x[[2]] == 2L | x[[2]] == 3L)
+        }
+        return(T)
+    }
 
-    if (!all(two_args)) {
-        culprits <- likelihoods_names[!two_args]
-        msg <- paste0("The following likelihoods dont' have two arguments: ",
-                      paste(culprits, collapse = ", "))
+    legal_arity <- vapply(likelihoods, arity_two_or_three, logical(1))
+
+    if (!all(legal_arity)) {
+        culprits <- likelihood_names[!legal_arity]
+        msg <- paste0("The following likelihoods do not have arity two or three: ",
+                      paste(culprits, collapse=", "))
         stop(msg)
     }
 
-
+    names(likelihoods) <- likelihoods_names
     class(likelihoods) <- c("custom_likelihoods", "list")
     return(likelihoods)
-
 }
 
 

--- a/R/outbreaker_find_imports.R
+++ b/R/outbreaker_find_imports.R
@@ -33,7 +33,7 @@ outbreaker_find_imports <- function(moves, data, param_current,
 
   ## remove the contact likelihood from outlier detection
   tmp_likelihoods <- likelihoods
-  tmp_likelihoods$contact <- function(data, param) return(0)
+  tmp_likelihoods$contact <- list(function(data, param) return(0), 0)
 
   ## RUN MCMC ##
   for (i in seq.int(2, config$n_iter_import, 1)) {

--- a/src/likelihoods.cpp
+++ b/src/likelihoods.cpp
@@ -56,7 +56,11 @@ double cpp_ll_genetic(Rcpp::List data, Rcpp::List param, SEXP i,
   size_t N = static_cast<size_t>(data["N"]);
   if (N < 2) return 0.0;
 
-  if (custom_function == R_NilValue) {
+  Rcpp::List l;
+  if (custom_function != R_NilValue) {
+    l = Rcpp::as<Rcpp::List>(custom_function);
+  }
+  if (custom_function == R_NilValue || (l.size() > 0 && l[0] == R_NilValue)) {
 
     // Variables from the data & param
     Rcpp::NumericMatrix w_dens = data["log_w_dens"];
@@ -169,8 +173,9 @@ double cpp_ll_genetic(Rcpp::List data, Rcpp::List param, SEXP i,
     return(out);
     
   } else { // use of a customized likelihood function
-    Rcpp::Function f = Rcpp::as<Rcpp::Function>(custom_function);
-
+    Rcpp::Function f = Rcpp::as<Rcpp::Function>(l[0]);
+    int arity = l[1];
+    if (arity == 3) return Rcpp::as<double>(f(data, param, i));
     return Rcpp::as<double>(f(data, param));
   }
 }
@@ -198,7 +203,11 @@ double cpp_ll_timing_infections(Rcpp::List data, Rcpp::List param, SEXP i,
   size_t N = static_cast<size_t>(data["N"]);
   if(N < 2) return 0.0;
 
-  if (custom_function == R_NilValue) {
+  Rcpp::List l;
+  if (custom_function != R_NilValue) {
+    l = Rcpp::as<Rcpp::List>(custom_function);
+  }
+  if (custom_function == R_NilValue || (l.size() > 0 && l[0] == R_NilValue)) {
 
     Rcpp::IntegerVector alpha = param["alpha"];
     Rcpp::IntegerVector t_inf = param["t_inf"];
@@ -246,8 +255,9 @@ double cpp_ll_timing_infections(Rcpp::List data, Rcpp::List param, SEXP i,
 
     return out;
   } else { // use of a customized likelihood function
-    Rcpp::Function f = Rcpp::as<Rcpp::Function>(custom_function);
-
+    Rcpp::Function f = Rcpp::as<Rcpp::Function>(l[0]);
+    int arity = l[1];
+    if (arity == 3) return Rcpp::as<double>(f(data, param, i));
     return Rcpp::as<double>(f(data, param));
   }
 }
@@ -275,7 +285,11 @@ double cpp_ll_timing_sampling(Rcpp::List data, Rcpp::List param, SEXP i,
   size_t N = static_cast<size_t>(data["N"]);
   if(N < 2) return 0.0;
 
-  if (custom_function == R_NilValue) {
+  Rcpp::List l;
+  if (custom_function != R_NilValue) {
+    l = Rcpp::as<Rcpp::List>(custom_function);
+  }
+  if (custom_function == R_NilValue || (l.size() > 0 && l[0] == R_NilValue)) {
 
     Rcpp::IntegerVector dates = data["dates"];
     Rcpp::IntegerVector t_inf = param["t_inf"];
@@ -308,8 +322,9 @@ double cpp_ll_timing_sampling(Rcpp::List data, Rcpp::List param, SEXP i,
 
     return out;
   }  else { // use of a customized likelihood function
-    Rcpp::Function f = Rcpp::as<Rcpp::Function>(custom_function);
-
+    Rcpp::Function f = Rcpp::as<Rcpp::Function>(l[0]);
+    int arity = l[1];
+    if (arity == 3) return Rcpp::as<double>(f(data, param, i));
     return Rcpp::as<double>(f(data, param));
   }
 }
@@ -354,7 +369,11 @@ double cpp_ll_reporting(Rcpp::List data, Rcpp::List param, SEXP i,
     return R_NegInf;
   }
 
-  if (custom_function == R_NilValue) {
+  Rcpp::List l;
+  if (custom_function != R_NilValue) {
+    l = Rcpp::as<Rcpp::List>(custom_function);
+  }
+  if (custom_function == R_NilValue || (l.size() > 0 && l[0] == R_NilValue)) {
 
     double out = 0.0;
 
@@ -385,8 +404,9 @@ double cpp_ll_reporting(Rcpp::List data, Rcpp::List param, SEXP i,
 
     return out;
   } else { // use of a customized likelihood function
-    Rcpp::Function f = Rcpp::as<Rcpp::Function>(custom_function);
-
+    Rcpp::Function f = Rcpp::as<Rcpp::Function>(l[0]);
+    int arity = l[1];
+    if (arity == 3) return Rcpp::as<double>(f(data, param, i));
     return Rcpp::as<double>(f(data, param));
   }
 }
@@ -435,7 +455,11 @@ double cpp_ll_contact(Rcpp::List data, Rcpp::List param, SEXP i,
   size_t N = static_cast<size_t>(data["N"]);
   if (N < 2) return 0.0;
 
-  if (custom_function == R_NilValue) {
+  Rcpp::List l;
+  if (custom_function != R_NilValue) {
+    l = Rcpp::as<Rcpp::List>(custom_function);
+  }
+  if (custom_function == R_NilValue || (l.size() > 0 && l[0] == R_NilValue)) {
 
     double out;
     double eps = Rcpp::as<double>(param["eps"]);
@@ -497,8 +521,9 @@ double cpp_ll_contact(Rcpp::List data, Rcpp::List param, SEXP i,
     return out;
     
   } else { //use of a customized likelihood function
-    Rcpp::Function f = Rcpp::as<Rcpp::Function>(custom_function);
-
+    Rcpp::Function f = Rcpp::as<Rcpp::Function>(l[0]);
+    int arity = l[1];
+    if (arity == 3) return Rcpp::as<double>(f(data, param, i));
     return Rcpp::as<double>(f(data, param));
   }
 }


### PR DESCRIPTION
Currently, when custom likelihood functions are registered, they do not accept the `i` parameter that the default likelihoods use to calculate the local likelihood delta without having to calculate the likelihood of the entire tree. The likelihood functions are called multiple times in each iteration, so the speedup of not having to calculate the likelihoods for the entire tree every single time they are called is significant.

This PR wraps the custom likelihood functions into (function, arity) pairs, since the arity of a function apparently cannot be assessed on the C++ side. If the arity of a custom likelihood function is three, the `i` parameter is passed to it, otherwise it is just called with `data, param` as its arguments.

This means that e.g. a custom genetic likelihood function `genetic_two <- function(data, param)` will be passed to `cpp_ll_all` as `list(genetic_two, 2)` while `genetic_three <- function(data, param, i)` will be passed as `list(genetic_three, 3)`.

The API is the same as it was, and the signature for `cpp_ll_all` is the same as it was. However, if for some reason anyone needs to call a default likelihood function _directly_ and _also_ pass a custom likelihood function to it, they need to wrap the custom likelihood function in a list along with its arity. I know this is less than ideal, but I cannot see a use case for calling the default likelihood functions directly in such a way.

This is a slightly clunky way of doing this and I'm open to suggestions. However, I still think this is the _least_ clunky approach. My initial thought was to do this with try-catch statements rather than having to pass the arity along with all the functions, but it seems to me that Rcpp does not define a lot of exceptions so that approach could potentially silence some exceptions that should be passed to the user. This is more of a traditional ask-permission-rather-than-forgiveness approach. Another way would be to pass the `methods::formalArgs` function to the C++ log-likelihood functions, but that would be even clunkier.